### PR TITLE
Add badge for android-gems.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Android Gems](http://www.android-gems.com/badge/Toolwiz/ToolWizAppLock.svg?branch=master)](http://www.android-gems.com/lib/Toolwiz/ToolWizAppLock)
+
 #ToolWizAppLock - Smart App Lock
 ##About
 


### PR DESCRIPTION
Added badge for android-gems: http://www.android-gems.com/lib/Toolwiz/ToolWizAppLock , it looks like this:

[![Android Gems](http://www.android-gems.com/badge/Toolwiz/ToolWizAppLock.svg?branch=master)](http://www.android-gems.com/lib/Toolwiz/ToolWizAppLock)
